### PR TITLE
Fix bindAll for Android 8+

### DIFF
--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -1665,7 +1665,9 @@ public class WifiWizard2 extends CordovaPlugin {
           connectivityManager.bindProcessToNetwork(network);
         }
       };
-
+      
+      connectivityManager.requestNetwork(request, networkCallback);
+      
       // Only lollipop (API 21 && 22) use setProcessDefaultNetwork, API < 21 already does this by default
     } else if( API_VERSION >= 21 && API_VERSION < 23 ){
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
BugFix - BindAll was not working on my Google Pixel 8.1 on a Wifi network with no internet, After adding this line everything started to work.

Added 

` connectivityManager.requestNetwork(request, networkCallback); ` 
to the bindAll part, looks like it was just missing.

