### PR TITLE
Update iOSConnectNetwork to return real response in promise

### DIFF
--- a/src/ios/WifiWizard2.m
+++ b/src/ios/WifiWizard2.m
@@ -38,7 +38,8 @@
 }
 
 - (void)iOSConnectNetwork:(CDVInvokedUrlCommand*)command {
-    CDVPluginResult *pluginResult = nil;
+    
+    __block CDVPluginResult *pluginResult = nil;
 
 	NSString * ssidString;
 	NSString * passwordString;
@@ -55,19 +56,38 @@
 					passphrase:passwordString 
 						isWEP:(BOOL)false];
 
-			configuration.joinOnce = YES;
-			[[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:nil];
-			pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:ssidString];
+			configuration.joinOnce = false;
+            
+            [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
+                
+                NSDictionary *r = [self fetchSSIDInfo];
+                
+                NSString *ssid = [r objectForKey:(id)kCNNetworkInfoKeySSID]; //@"SSID"
+                
+                if (ssid == ssidString){
+                    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:ssidString];
+                }else{
+                    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.description];
+                }
+                [self.commandDelegate sendPluginResult:pluginResult
+                                            callbackId:command.callbackId];
+            }];
+
+
 		} else {
 			pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"SSID Not provided"];
+            [self.commandDelegate sendPluginResult:pluginResult
+                                        callbackId:command.callbackId];
 		}
 	} else {
 		pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"iOS 11+ not available"];
+        [self.commandDelegate sendPluginResult:pluginResult
+                                    callbackId:command.callbackId];
 	}
 
-    [self.commandDelegate sendPluginResult:pluginResult
-                                callbackId:command.callbackId];
+
 }
+
 
 - (void)iOSDisconnectNetwork:(CDVInvokedUrlCommand*)command {
     CDVPluginResult *pluginResult = nil;

--- a/src/ios/WifiWizard2.m
+++ b/src/ios/WifiWizard2.m
@@ -64,7 +64,7 @@
                 
                 NSString *ssid = [r objectForKey:(id)kCNNetworkInfoKeySSID]; //@"SSID"
                 
-                if (ssid == ssidString){
+                if ([ssid isEqualToString:ssidString]){
                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:ssidString];
                 }else{
                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.description];


### PR DESCRIPTION
### Description of the Change

iOSConnectNetwork resolve right away without waiting for success/failure, This PR fixes that. 
This PR will also validate we're on the connected SSID before resolving.

### Why Should This Be In Core?

Fixes iOSConnectNetwork to work as expected

### Possible Drawbacks

None.

