### PR TITLE
Add isHiddenSSID config for connecting Android devices to hidden networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ I have changed the way this works in WifiWizard2 version 3.0.0+, converting it t
 If the connect method is unable to update existing network configuration (added by user or other apps), but there is a valid network ID, it will still attempt to enable that network ID.
 
 ```javascript
-WifiWizard2.connect(ssid, bindAll, password, algorithm)
+WifiWizard2.connect(ssid, bindAll, password, algorithm, isHiddenSSID)
 ```
  - `ssid` should be the SSID to connect to *required*
  - `bindAll` should be set to `true` to tell Android to route all connections from your Android app, through the wifi connection (default is `false`) *optional*
@@ -99,6 +99,7 @@ WifiWizard2.connect(ssid, bindAll, password, algorithm)
  - `algorithm` and `password` is not required if connecting to an open network
  - Currently `WPA` and `WEP` are only supported algorithms
  - For `WPA2` just pass `WPA` as the algorithm
+ - Set `isHiddenSSID` to `true` if the network you're connecting to is hidden
  - These arguments are the same as for `formatWifiConfig`
  - This method essentially calls `formatWifiConfig` then `add` then `enable`
  - If unable to update network configuration (was added by user or other app), but a valid network ID exists, this method will still attempt to enable the network
@@ -129,15 +130,16 @@ WifiWizard2.disconnect(ssid)
  - `ERROR_DISCONNECT` - Android error disconnecting wifi (only when SSID is not passed)
 
 ```javascript
-WifiWizard2.formatWifiConfig(ssid, password, algorithm)
+WifiWizard2.formatWifiConfig(ssid, password, algorithm, isHiddenSSID)
 ```
  - `algorithm` and `password` is not required if connecting to an open network
  - Currently `WPA` and `WEP` are only supported algorithms
  - For `WPA2` just pass `WPA` as the algorithm
+ - Set `isHiddenSSID` to `true` if the network you're connecting to is hidden
 ```javascript
-WifiWizard2.formatWPAConfig(ssid, password)
+WifiWizard2.formatWPAConfig(ssid, password, isHiddenSSID)
 ```
- - This is just a helper method that calls `WifiWizard2.formatWifiConfig( ssid, password, 'WPA' );`
+ - This is just a helper method that calls `WifiWizard2.formatWifiConfig( ssid, password, 'WPA', isHiddenSSID );`
 
 ```javascript
 WifiWizard2.add(wifi)

--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -348,22 +348,27 @@ public class WifiWizard2 extends CordovaPlugin {
     WifiConfiguration wifi = new WifiConfiguration();
 
     try {
-      // data's order for ANY object is 0: ssid, 1: authentication algorithm,
-      // 2+: authentication information.
+      // data's order for ANY object is
+      // 0: SSID
+      // 1: authentication algorithm,
+      // 2: authentication information
+      // 3: whether or not the SSID is hidden
+      String newSSID = data.getString(0);
       String authType = data.getString(1);
+      String newPass = data.getString(2);
+      boolean isHiddenSSID = data.getBoolean(3);
 
-      /**
-       * WPA Data format:
-       * 0: ssid
-       * 1: auth
-       * 2: password
-       */
+      wifi.hiddenSSID = isHiddenSSID;
 
       if (authType.equals("WPA") || authType.equals("WPA2")) {
-        // WPA/WPA2 NETWORK
-        String newSSID = data.getString(0);
+       /**
+        * WPA Data format:
+        * 0: ssid
+        * 1: auth
+        * 2: password
+        * 3: isHiddenSSID
+        */
         wifi.SSID = newSSID;
-        String newPass = data.getString(2);
         wifi.preSharedKey = newPass;
 
         wifi.status = WifiConfiguration.Status.ENABLED;
@@ -378,14 +383,14 @@ public class WifiWizard2 extends CordovaPlugin {
         wifi.networkId = ssidToNetworkId(newSSID);
 
       } else if (authType.equals("WEP")) {
-        // WEP NETWORK
-        // WEP Data format:
-        // 0: ssid
-        // 1: auth
-        // 2: password
-        String newSSID = data.getString(0);
+       /**
+        * WEP Data format:
+        * 0: ssid
+        * 1: auth
+        * 2: password
+        * 3: isHiddenSSID
+        */
         wifi.SSID = newSSID;
-        String newPass = data.getString(2);
 
         if (getHexKey(newPass)) {
           wifi.wepKeys[0] = newPass;
@@ -410,8 +415,13 @@ public class WifiWizard2 extends CordovaPlugin {
         wifi.networkId = ssidToNetworkId(newSSID);
 
       } else if (authType.equals("NONE")) {
-        // OPEN NETWORK
-        String newSSID = data.getString(0);
+       /**
+        * OPEN Network data format:
+        * 0: ssid
+        * 1: auth
+        * 2: <not used>
+        * 3: isHiddenSSID
+        */
         wifi.SSID = newSSID;
         wifi.allowedKeyManagement.set(WifiConfiguration.KeyMgmt.NONE);
         wifi.networkId = ssidToNetworkId(newSSID);

--- a/www/WifiWizard2.js
+++ b/www/WifiWizard2.js
@@ -75,6 +75,8 @@ var WifiWizard2 = {
 							break;
 						case "NONE":
 							networkInformation.push("NONE");
+							// Adding twice for data structure consistency
+							networkInformation.push("NONE");
 							break;
 						case "Newly supported type":
 							break;
@@ -87,6 +89,7 @@ var WifiWizard2 = {
 					return false;
 				}
 
+				networkInformation.push(!!wifi.isHiddenSSID)
 				cordova.exec(resolve, reject, "WifiWizard2", "add", networkInformation);
 
 			} else {
@@ -118,7 +121,7 @@ var WifiWizard2 = {
 	 * @param {string} [algorithm=NONE]			WPA, WPA (for WPA2), WEP or NONE (NONE by default)
    * @returns {Promise<any>}
    */
-  connect: function ( SSID, bindAll, password, algorithm ) {
+  connect: function ( SSID, bindAll, password, algorithm, isHiddenSSID ) {
     return new Promise( function( resolve, reject ){
 
       if( ! SSID ){
@@ -126,7 +129,7 @@ var WifiWizard2 = {
         return;
       }
 
-      var wifiConfig = WifiWizard2.formatWifiConfig( SSID, password, algorithm );
+      var wifiConfig = WifiWizard2.formatWifiConfig( SSID, password, algorithm, isHiddenSSID );
       bindAll = bindAll ? true : false;
 
       if( ! wifiConfig ){
@@ -457,11 +460,13 @@ var WifiWizard2 = {
 	 * @param {string|int} [SSID]
 	 * @param {string} [password]
 	 * @param {string} [algorithm]
+	 * @param {boolean} [isHiddenSSID]
 	 * @returns {*}
 	 */
-	formatWifiConfig: function (SSID, password, algorithm) {
+	formatWifiConfig: function (SSID, password, algorithm, isHiddenSSID) {
 		var wifiConfig = {
-			SSID: WifiWizard2.formatWifiString(SSID)
+			SSID: WifiWizard2.formatWifiString(SSID),
+			isHiddenSSID: !!isHiddenSSID
 		};
 		if (!algorithm && !password) {
 			// open network
@@ -498,11 +503,12 @@ var WifiWizard2 = {
 	/**
 	 * Format WPA WiFi configuration for Android Devices
 	 * @param {string|int} [SSID]
-	 * @param password
+	 * @param {string} password
+	 * @param {boolean} isHiddenSSID
 	 * @returns {*}
 	 */
-	formatWPAConfig: function (SSID, password) {
-		return WifiWizard2.formatWifiConfig(SSID, password, "WPA");
+	formatWPAConfig: function (SSID, password, isHiddenSSID) {
+		return WifiWizard2.formatWifiConfig(SSID, password, "WPA", isHiddenSSID);
 	},
 
 	/**


### PR DESCRIPTION
### Description of the Change

Due to the inner workings of Android's wifi manager, if the network is hidden, an SSID-based probe request will be used - but there was no way to enable this option.

See https://developer.android.com/reference/android/net/wifi/WifiConfiguration.html#hiddenSSID

### Alternate Designs

Could not see any other logical methods to implement this.

### Why Should This Be In Core?

It allows Android to connect to hidden SSID's - iOS has no problem doing so, but Android does.

### Benefits

:point_up: 

### Possible Drawbacks

None, if `isHiddenSSID` is not set then the plugin acts as normal.