### PR TITLE
fix(#46): Object cannot be converted to int

### DIFF
--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -738,7 +738,7 @@ public class WifiWizard2 extends CordovaPlugin {
     @Override
     protected String[] doInBackground(Object... params) {
       this.callbackContext = (CallbackContext) params[0];
-      int networkIdToConnect = (int) params[1];
+      int networkIdToConnect = (Integer) params[1];
 
       final int TIMES_TO_RETRY = 15;
       for (int i = 0; i < TIMES_TO_RETRY; i++) {


### PR DESCRIPTION
### Description of the Change

Fixes the error that is thrown when building for Android. Originally proposed by @duzc2 in #46.

### Alternate Designs

None

### Why Should This Be In Core?
☝️ 

### Benefits

☝️ 

### Possible Drawbacks

None

### Applicable Issues

#46 