### PR TITLE
Remove es6-promise-plugin dependency

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -16,9 +16,6 @@
         <clobbers target="window.WifiWizard2" />
     </js-module>
 
-    <!-- ES6 promise polyfill -->
-    <dependency id="es6-promise-plugin" version="4.1.0" />
-
     <!-- android -->
     <platform name="android">
 


### PR DESCRIPTION
### Description of the Change

Remove the dependency on the `es6-promise-plugin` cordova plugin.

### Benefits

Most modern web views ([WKWebView](https://developer.apple.com/documentation/webkit/wkwebview) on iOS and [WebView](https://developer.android.com/reference/android/webkit/WebView) on Android) have supported promises for a while now. This means having `es6-promise-plugin` as a dependency does not serve any purpose and it only adds bloat to a project that doesn't need it.

### Possible Drawbacks

Removing `es6-promise-plugin` as a dependency from this plugin might break apps that are using some older webviews which don't have native support for promises (and don't provide any other promise polyfill). However, that's easy to fix by adding this plugin as a dependency on the projects that actually need it, rather than have it as a transitive dependency from this plugin.