### PR TITLE
Add wifi-info capabilities

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -64,6 +64,12 @@
         <config-file parent="com.apple.developer.networking.networkextension" target="*/Entitlements-Release.plist">
                 <array/>
         </config-file>
+	<config-file parent="com.apple.developer.networking.wifi-info" target="*/Entitlements-Debug.plist">
+                <true/>
+        </config-file>
+        <config-file parent="com.apple.developer.networking.wifi-info" target="*/Entitlements-Release.plist">
+                <true/>
+        </config-file>
             
         <header-file src="src/ios/WifiWizard2.h" />
         <source-file src="src/ios/WifiWizard2.m" />


### PR DESCRIPTION
### Description of the Change

iOS 12 added a new requirement if you need wifi info, this was discussed on #53


### Why Should This Be In Core?

Would be great to have this out of the box since the purpose of this plugin is to use the wifi info 


### Possible Drawbacks

None

### Applicable Issues

#53 


Based on @msari-ipe-ext-1 suggestion, Thanks