### PR TITLE
* NSLog pollutes the console when we request the ssid using a interval

### DIFF
--- a/src/ios/WifiWizard2.m
+++ b/src/ios/WifiWizard2.m
@@ -9,11 +9,11 @@
 - (id)fetchSSIDInfo {
     // see http://stackoverflow.com/a/5198968/907720
     NSArray *ifs = (__bridge_transfer NSArray *)CNCopySupportedInterfaces();
-    NSLog(@"Supported interfaces: %@", ifs);
+    // NSLog(@"Supported interfaces: %@", ifs);
     NSDictionary *info;
     for (NSString *ifnam in ifs) {
         info = (__bridge_transfer NSDictionary *)CNCopyCurrentNetworkInfo((__bridge CFStringRef)ifnam);
-        NSLog(@"%@ => %@", ifnam, info);
+        // NSLog(@"%@ => %@", ifnam, info);
         if (info && [info count]) { break; }
     }
     return info;


### PR DESCRIPTION
The debug log should be disabled. We need to poll the wifi ssid to trigger some logic. I did not fpund a way (using this plugin) to get a callback when the ssid changes (or I am missing something).

best regards 