### PR TITLE
#71 Prompt to enable location services if device is Android 9+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WiFiWizard2 - 3.1.0<!-- omit in toc -->
+# WiFiWizard2 - 3.1.1<!-- omit in toc -->
 
 Table of Contents<!-- omit in toc -->
 ---

--- a/README.md
+++ b/README.md
@@ -459,6 +459,8 @@ wifiConnection.then( result => {
 Apache 2.0
 
 # Changelog:
+**3.1.1** - April 4, 2019
+- Fixed/Added location services check for Android 9+ for any method that utilises the getConnectionInfo method
 
 **3.1.0** - August 28, 2018
 - Fixed/Added compatibility with iOS to connect to open network

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Run ```cordova plugin add https://github.com/tripflex/wifiwizard2```
 To install from the master branch (latest on GitHub)
 
 To install a specific branch (add `#tag` replacing `tag` with tag from this repo, example:
-```cordova plugin add https://github.com/tripflex/wifiwizard2#v3.1.0```
+```cordova plugin add https://github.com/tripflex/wifiwizard2#v3.1.1```
 
 Find available tags here:
 https://github.com/tripflex/WifiWizard2/tags
@@ -426,9 +426,9 @@ Run ```cordova plugin add cordova-plugin-wifiwizard2```
 To install and use this plugin in a Meteor project, you have to specify the exact version from NPM repository:
 [https://www.npmjs.com/package/cordova-plugin-wifiwizard2](https://www.npmjs.com/package/cordova-plugin-wifiwizard2)
 
-As of 8/28/2018, the latest version is 3.1.0:
+As of April 4th 2019, the latest version is 3.1.1:
 
-```meteor add cordova:cordova-plugin-wifiwizard2@3.1.0```
+```meteor add cordova:cordova-plugin-wifiwizard2@3.1.1```
 
 # Errors/Rejections
 Methods now return formatted string errors as detailed below, instead of returning generic error messages.  This allows you to check yourself what specific error was returned, and customize the error message.

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Apache 2.0
 
 # Changelog:
 **3.1.1** - April 4, 2019
-- Fixed/Added location services check for Android 9+ for any method that utilises the getConnectionInfo method
+- Fixed/Added location services check for Android 9+ for any method that utilises the getConnectionInfo method. Issue #71 (@arsenal942) 
 
 **3.1.0** - August 28, 2018
 - Fixed/Added compatibility with iOS to connect to open network

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-wifiwizard2",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "cordova": {
     "id": "wifiwizard2",
     "platforms": [

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "cordova-plugin-wifiwizard2-arsenal942",
+  "name": "cordova-plugin-wifiwizard2",
   "version": "3.1.1",
   "cordova": {
-    "id": "wifiwizard2-arsenal942",
+    "id": "wifiwizard2",
     "platforms": [
       "android",
       "ios"
@@ -10,13 +10,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/arsenal942/WifiWizard2.git"
+    "url": "git+https://github.com/tripflex/wifiwizard2.git"
   },
   "author": "Myles McNamara",
   "license": "Apache 2.0",
   "description": "Cordova WiFi Manager for Android and iOS",
   "bugs": {
-    "url": "https://github.com/arsenal942/WifiWizard2/issues"
+    "url": "https://github.com/tripflex/wifiwizard2/issues"
   },
   "engines": {
     "cordovaDependencies": {
@@ -25,7 +25,7 @@
       }
     }
   },
-  "homepage": "https://github.com/arsenal942/WifiWizard2#readme",
+  "homepage": "https://github.com/tripflex/wifiwizard2#readme",
   "keywords": [
     "ecosystem:cordova",
     "cordova-android",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "cordova-plugin-wifiwizard2",
+  "name": "cordova-plugin-wifiwizard2-arsenal942",
   "version": "3.1.1",
   "cordova": {
-    "id": "wifiwizard2",
+    "id": "wifiwizard2-arsenal942",
     "platforms": [
       "android",
       "ios"
@@ -10,13 +10,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tripflex/wifiwizard2.git"
+    "url": "git+https://github.com/arsenal942/WifiWizard2.git"
   },
   "author": "Myles McNamara",
   "license": "Apache 2.0",
   "description": "Cordova WiFi Manager for Android and iOS",
   "bugs": {
-    "url": "https://github.com/tripflex/wifiwizard2/issues"
+    "url": "https://github.com/arsenal942/WifiWizard2/issues"
   },
   "engines": {
     "cordovaDependencies": {
@@ -25,7 +25,7 @@
       }
     }
   },
-  "homepage": "https://github.com/tripflex/wifiwizard2#readme",
+  "homepage": "https://github.com/arsenal942/WifiWizard2#readme",
   "keywords": [
     "ecosystem:cordova",
     "cordova-android",

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="wifiwizard2"
-        version="3.1.0">
+        version="3.1.1">
 
     <name>WifiWizard2</name>
     <description>Cordova Wifi Manager for Android and iOS</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,15 +2,15 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
-        id="wifiwizard2-arsenal942"
+        id="wifiwizard2"
         version="3.1.1">
 
     <name>WifiWizard2</name>
     <description>Cordova Wifi Manager for Android and iOS</description>
     <license>Apache 2.0</license>
     <keywords>cordova,network,wifi,phonegap</keywords>
-    <repo>https://github.com/arsenal942/WifiWizard2/wifiwizard2.git</repo>
-    <issue>https://github.com/arsenal942/WifiWizard2/wifiwizard2/issues</issue>
+    <repo>https://github.com/tripflex/wifiwizard2.git</repo>
+    <issue>https://github.com/tripflex/wifiwizard2/issues</issue>
 
     <js-module src="www/WifiWizard2.js" name="WifiWizard2">
         <clobbers target="window.WifiWizard2" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,15 +2,15 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
-        id="wifiwizard2"
+        id="wifiwizard2-arsenal942"
         version="3.1.1">
 
     <name>WifiWizard2</name>
     <description>Cordova Wifi Manager for Android and iOS</description>
     <license>Apache 2.0</license>
     <keywords>cordova,network,wifi,phonegap</keywords>
-    <repo>https://github.com/tripflex/wifiwizard2.git</repo>
-    <issue>https://github.com/tripflex/wifiwizard2/issues</issue>
+    <repo>https://github.com/arsenal942/WifiWizard2/wifiwizard2.git</repo>
+    <issue>https://github.com/arsenal942/WifiWizard2/wifiwizard2/issues</issue>
 
     <js-module src="www/WifiWizard2.js" name="WifiWizard2">
         <clobbers target="window.WifiWizard2" />

--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -1130,8 +1130,11 @@ public class WifiWizard2 extends CordovaPlugin {
    * @param basicIdentifier A flag to get BSSID if true or SSID if false.
    * @return true if SSID found, false if not.
    */
-  private boolean getWifiServiceInfo(CallbackContext callbackContext, boolean basicIdentifier) {
-    if (cordova.hasPermission(ACCESS_FINE_LOCATION)) {
+  private boolean getWifiServiceInfo(CallbackContext callbackContext, boolean basicIdentifier) {    
+    if (API_VERSION >= 28 && !cordova.hasPermission(ACCESS_FINE_LOCATION)) { //Android 9 (Pie) or newer
+      requestLocationPermission(WIFI_SERVICE_INFO_CODE);
+      return true;
+    } else {
       WifiInfo info = wifiManager.getConnectionInfo();
 
       if (info == null) {
@@ -1164,9 +1167,6 @@ public class WifiWizard2 extends CordovaPlugin {
       }
   
       callbackContext.success(serviceInfo);
-      return true;
-    } else {
-      requestLocationPermission(WIFI_SERVICE_INFO_CODE);
       return true;
     }
   }
@@ -1472,7 +1472,7 @@ public class WifiWizard2 extends CordovaPlugin {
         callbackContext.success("PERMISSION_GRANTED");
         break;
       case WIFI_SERVICE_INFO_CODE:
-        getWifiServiceInfo(callbackContext, passedData);
+        callbackContext.success("PERMISSION_GRANTED");
         break;
     }
   }

--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -89,6 +89,7 @@ public class WifiWizard2 extends CordovaPlugin {
   private static final int SCAN_RESULTS_CODE = 0; // Permissions request code for getScanResults()
   private static final int SCAN_CODE = 1; // Permissions request code for scan()
   private static final int LOCATION_REQUEST_CODE = 2; // Permissions request code
+  private static final int WIFI_SERVICE_INFO_CODE = 3;
   private static final String ACCESS_FINE_LOCATION = android.Manifest.permission.ACCESS_FINE_LOCATION;
 
   private static int LAST_NET_ID = -1;
@@ -1130,40 +1131,44 @@ public class WifiWizard2 extends CordovaPlugin {
    * @return true if SSID found, false if not.
    */
   private boolean getWifiServiceInfo(CallbackContext callbackContext, boolean basicIdentifier) {
+    if (cordova.hasPermission(ACCESS_FINE_LOCATION)) {
+      WifiInfo info = wifiManager.getConnectionInfo();
 
-    WifiInfo info = wifiManager.getConnectionInfo();
-
-    if (info == null) {
-      callbackContext.error("UNABLE_TO_READ_WIFI_INFO");
-      return false;
-    }
-
-    // Only return SSID or BSSID when actually connected to a network
-    SupplicantState state = info.getSupplicantState();
-    if (!state.equals(SupplicantState.COMPLETED)) {
-      callbackContext.error("CONNECTION_NOT_COMPLETED");
-      return false;
-    }
-
-    String serviceInfo;
-    if (basicIdentifier) {
-      serviceInfo = info.getBSSID();
+      if (info == null) {
+        callbackContext.error("UNABLE_TO_READ_WIFI_INFO");
+        return false;
+      }
+  
+      // Only return SSID or BSSID when actually connected to a network
+      SupplicantState state = info.getSupplicantState();
+      if (!state.equals(SupplicantState.COMPLETED)) {
+        callbackContext.error("CONNECTION_NOT_COMPLETED");
+        return false;
+      }
+  
+      String serviceInfo;
+      if (basicIdentifier) {
+        serviceInfo = info.getBSSID();
+      } else {
+        serviceInfo = info.getSSID();
+      }
+  
+      if (serviceInfo == null || serviceInfo.isEmpty() || serviceInfo == "0x") {
+        callbackContext.error("WIFI_INFORMATION_EMPTY");
+        return false;
+      }
+  
+      // http://developer.android.com/reference/android/net/wifi/WifiInfo.html#getSSID()
+      if (serviceInfo.startsWith("\"") && serviceInfo.endsWith("\"")) {
+        serviceInfo = serviceInfo.substring(1, serviceInfo.length() - 1);
+      }
+  
+      callbackContext.success(serviceInfo);
+      return true;
     } else {
-      serviceInfo = info.getSSID();
+      requestLocationPermission(WIFI_SERVICE_INFO_CODE);
+      return true;
     }
-
-    if (serviceInfo == null || serviceInfo.isEmpty() || serviceInfo == "0x") {
-      callbackContext.error("WIFI_INFORMATION_EMPTY");
-      return false;
-    }
-
-    // http://developer.android.com/reference/android/net/wifi/WifiInfo.html#getSSID()
-    if (serviceInfo.startsWith("\"") && serviceInfo.endsWith("\"")) {
-      serviceInfo = serviceInfo.substring(1, serviceInfo.length() - 1);
-    }
-
-    callbackContext.success(serviceInfo);
-    return true;
   }
 
   /**
@@ -1458,16 +1463,18 @@ public class WifiWizard2 extends CordovaPlugin {
 
     switch (requestCode) {
       case SCAN_RESULTS_CODE:
-        getScanResults(callbackContext, passedData ); // Call method again after permissions approved
+        getScanResults(callbackContext, passedData); // Call method again after permissions approved
         break;
       case SCAN_CODE:
-        scan(callbackContext, passedData ); // Call method again after permissions approved
+        scan(callbackContext, passedData); // Call method again after permissions approved
         break;
       case LOCATION_REQUEST_CODE:
         callbackContext.success("PERMISSION_GRANTED");
         break;
+      case WIFI_SERVICE_INFO_CODE:
+        getWifiServiceInfo(callbackContext, passedData);
+        break;
     }
-
   }
 
   /**


### PR DESCRIPTION
### Description of the Change

- Added a check that determines if the device is Android 9+ and if they have location services enabled.
-- If not enabled, it will prompt them to enable them

### Alternate Designs

n/a

### Why Should This Be In Core?

Because the plugin breaks for Android 9+ if we don't have it

### Benefits

Will enable Android 9+ devices to utilise the getConnectionInfo method. The location services enabled check only fires if Android 9+ which is nice because it doesn't annoy users not on Android 9+

### Possible Drawbacks

n/a

### Applicable Issues

#71 