### PR TITLE
Expose bind & un-bind to cordova

### DIFF
--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -1669,6 +1669,42 @@ public class WifiWizard2 extends CordovaPlugin {
   }
 
   /**
+   * Will un-bind to network (use Cellular network)
+   *
+   * @param callbackContext A Cordova callback context
+   */
+  private void resetBindAll(CallbackContext callbackContext) {
+    Log.d(TAG, "WifiWizard2: resetBindALL");
+
+    try {
+      maybeResetBindALL();
+      callbackContext.success("Netwrok was unbind");
+    } catch (Exception e) {
+      Log.e(TAG, "InterruptedException error.", e);
+      callbackContext.error("ERROR_NO_BIND_ALL");
+    }
+  }
+
+  /**
+   * Will bind to network (use Wifi network)
+   *
+   * @param callbackContext A Cordova callback context
+   */
+  private void setBindAll(CallbackContext callbackContext) {
+    Log.d(TAG, "WifiWizard2: setBindALL");
+
+    try {
+      int networkId = getConnectedNetId();
+      registerBindALL(networkId);
+      callbackContext.success("Netwrok was bind");
+    } catch (Exception e) {
+      Log.e(TAG, "InterruptedException error.", e);
+      callbackContext.error("ERROR_CANT_BIND_ALL");
+    }
+  }
+
+
+  /**
    * Called after successful connection to WiFi when using BindAll feature
    *
    * This method is called by the NetworkChangedReceiver after network changed action, and confirming that we are in fact connected to wifi,

--- a/src/ios/WifiWizard2.h
+++ b/src/ios/WifiWizard2.h
@@ -6,20 +6,21 @@
 - (void)iOSConnectNetwork:(CDVInvokedUrlCommand *)command;
 - (void)iOSConnectOpenNetwork:(CDVInvokedUrlCommand *)command;
 - (void)iOSDisconnectNetwork:(CDVInvokedUrlCommand *)command;
-- (void)getConnectedSSID:(CDVInvokedUrlCommand*)command;
-- (void)getConnectedBSSID:(CDVInvokedUrlCommand*)command;
-- (void)isWifiEnabled:(CDVInvokedUrlCommand*)command;
-- (void)setWifiEnabled:(CDVInvokedUrlCommand*)command;
-- (void)scan:(CDVInvokedUrlCommand*)command;
+- (void)getConnectedSSID:(CDVInvokedUrlCommand *)command;
+- (void)getConnectedBSSID:(CDVInvokedUrlCommand *)command;
+- (void)isWifiEnabled:(CDVInvokedUrlCommand *)command;
+- (void)setWifiEnabled:(CDVInvokedUrlCommand *)command;
+- (void)scan:(CDVInvokedUrlCommand *)command;
 
 // Android Functions
-- (void)addNetwork:(CDVInvokedUrlCommand*)command;
-- (void)removeNetwork:(CDVInvokedUrlCommand*)command;
-- (void)androidConnectNetwork:(CDVInvokedUrlCommand*)command;
-- (void)androidDisconnectNetwork:(CDVInvokedUrlCommand*)command;
-- (void)listNetworks:(CDVInvokedUrlCommand*)command;
-- (void)getScanResults:(CDVInvokedUrlCommand*)command;
-- (void)startScan:(CDVInvokedUrlCommand*)command;
-- (void)disconnect:(CDVInvokedUrlCommand*)command;
+- (void)addNetwork:(CDVInvokedUrlCommand *)command;
+- (void)removeNetwork:(CDVInvokedUrlCommand *)command;
+- (void)androidConnectNetwork:(CDVInvokedUrlCommand *)command;
+- (void)androidDisconnectNetwork:(CDVInvokedUrlCommand *)command;
+- (void)listNetworks:(CDVInvokedUrlCommand *)command;
+- (void)getScanResults:(CDVInvokedUrlCommand *)command;
+- (void)startScan:(CDVInvokedUrlCommand *)command;
+- (void)disconnect:(CDVInvokedUrlCommand *)command;
+- (void)isConnectedToInternet:(CDVInvokedUrlCommand *)command;
 
 @end

--- a/src/ios/WifiWizard2.m
+++ b/src/ios/WifiWizard2.m
@@ -293,6 +293,14 @@
     [self.commandDelegate sendPluginResult:pluginResult
                                 callbackId:command.callbackId];
 }
+- (void)isConnectedToInternet:(CDVInvokedUrlCommand*)command {
+    CDVPluginResult *pluginResult = nil;
+    
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Not supported"];
+    
+    [self.commandDelegate sendPluginResult:pluginResult
+                                callbackId:command.callbackId];
+}
 
 
 @end

--- a/www/WifiWizard2.js
+++ b/www/WifiWizard2.js
@@ -343,6 +343,26 @@ var WifiWizard2 = {
     },
 
     /**
+	 * Unbind Network
+	 * @returns {Promise<any>}
+	 */
+	resetBindAll: function () {
+		return new Promise( function( resolve, reject ){
+			cordova.exec(resolve, reject, "WifiWizard2", "resetBindAll", []);
+		});
+	},
+
+	/**
+	 * Bind Network
+	 * @returns {Promise<any>}
+	 */
+	setBindAll: function () {
+		return new Promise( function( resolve, reject ){
+			cordova.exec(resolve, reject, "WifiWizard2", "setBindAll", []);
+		});
+    },
+    
+    /**
      * Get Wifi Router IP from DHCP
      * @returns {Promise<any>}
      */


### PR DESCRIPTION
### Description of the Change

IOT devices usually create a internet-less Wifi network, the *resetBindAll* and *setBindAll* allow us to toggle between Wifi and cellular without disconnecting (way faster)


### Why Should This Be In Core?

I use it on my fork for 6 months already, this has proven to be the only way I can toggle between the networks


* In addition i've added a missing method to iOS *isConnectedToInternet* - as "not supported" for now.
