### PR TITLE
Respect authentication type on Android

### DIFF
--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -1256,7 +1256,7 @@ public class WifiWizard2 extends CordovaPlugin {
             }
         }
       }
-      if (networkId == -1 && authType.substring(0,3).equals('WPA')) {
+      if (networkId == -1 && authType.substring(0,3).equals("WPA")) {
         for (WifiConfiguration test : currentNetworks) {
           if (test.SSID != null) {
               if (authType.length() == 0) {

--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -1240,32 +1240,32 @@ public class WifiWizard2 extends CordovaPlugin {
   }
 
 
-  public static final int SECURITY_NONE = 0;
-  public static final int SECURITY_WEP = 1;
-  public static final int SECURITY_PSK = 2;
-  public static final int SECURITY_EAP = 3;
+  static public String getSecurityType(WifiConfiguration wifiConfig) {
 
-  public static String getSecurityType(WifiConfiguration config) {
-      switch (getSecurity(config)) {
-          case SECURITY_WEP:
-              return "WEP";
-          case SECURITY_PSK:
-              if (config.allowedProtocols.get(WifiConfiguration.Protocol.RSN))
-                  return "WPA"; //Normally WPA2 but since we map everything to WPA it will be WPA
-              else
-                  return "WPA";
-          default:
-              return "NONE";
-      }
-  }
-  public static int getSecurity(WifiConfiguration config) {
-      if (config.allowedKeyManagement.get(WifiConfiguration.KeyMgmt.WPA_PSK)) 
-          return SECURITY_PSK;
-
-      if (config.allowedKeyManagement.get(WifiConfiguration.KeyMgmt.WPA_EAP) || config.allowedKeyManagement.get(WifiConfiguration.KeyMgmt.IEEE8021X)) 
-          return SECURITY_EAP;
-
-      return (config.wepKeys[0] != null) ? SECURITY_WEP : SECURITY_NONE;
+    if (wifiConfig.allowedKeyManagement.get(WifiConfiguration.KeyMgmt.NONE)) {
+        // If we never set group ciphers, wpa_supplicant puts all of them.
+        // For open, we don't set group ciphers.
+        // For WEP, we specifically only set WEP40 and WEP104, so CCMP
+        // and TKIP should not be there.
+        if (!wifiConfig.allowedGroupCiphers.get(WifiConfiguration.GroupCipher.CCMP)
+                && (wifiConfig.allowedGroupCiphers.get(WifiConfiguration.GroupCipher.WEP40)
+                        || wifiConfig.allowedGroupCiphers.get(WifiConfiguration.GroupCipher.WEP104))) {
+            return "WEP";
+        } else {
+            return "NONE";
+        }
+    } else if (wifiConfig.allowedProtocols.get(WifiConfiguration.Protocol.RSN)) {
+        return "WPA";//"WPA2";
+    } else if (wifiConfig.allowedKeyManagement.get(WifiConfiguration.KeyMgmt.WPA_EAP)) {
+        return "WPA";//"WPA_EAP";
+    } else if (wifiConfig.allowedKeyManagement.get(WifiConfiguration.KeyMgmt.IEEE8021X)) {
+        return "WPA";//"IEEE8021X";
+    } else if (wifiConfig.allowedProtocols.get(WifiConfiguration.Protocol.WPA)) {
+        return "WPA";
+    } else {
+        Log.w(TAG, "Unknown security type from WifiConfiguration, falling back on open.");
+        return "NONE";
+    }
   }
   /**
    * This method enables or disables the wifi

--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -375,7 +375,7 @@ public class WifiWizard2 extends CordovaPlugin {
 
       wifi.hiddenSSID = isHiddenSSID;
 
-      if (authType.equals("WPA") || authType.equals("WPA2")) {
+      if (authType.equals("WPA2")) {
        /**
         * WPA Data format:
         * 0: ssid
@@ -393,6 +393,27 @@ public class WifiWizard2 extends CordovaPlugin {
         wifi.allowedPairwiseCiphers.set(WifiConfiguration.PairwiseCipher.TKIP);
         wifi.allowedPairwiseCiphers.set(WifiConfiguration.PairwiseCipher.CCMP);
         wifi.allowedProtocols.set(WifiConfiguration.Protocol.RSN);
+        wifi.allowedProtocols.set(WifiConfiguration.Protocol.WPA);
+
+        wifi.networkId = ssidToNetworkId(newSSID, authType);
+
+      } else if (authType.equals("WPA")) {
+       /**
+        * WPA Data format:
+        * 0: ssid
+        * 1: auth
+        * 2: password
+        * 3: isHiddenSSID
+        */
+        wifi.SSID = newSSID;
+        wifi.preSharedKey = newPass;
+
+        wifi.status = WifiConfiguration.Status.ENABLED;
+        wifi.allowedGroupCiphers.set(WifiConfiguration.GroupCipher.TKIP);
+        wifi.allowedGroupCiphers.set(WifiConfiguration.GroupCipher.CCMP);
+        wifi.allowedKeyManagement.set(WifiConfiguration.KeyMgmt.WPA_PSK);
+        wifi.allowedPairwiseCiphers.set(WifiConfiguration.PairwiseCipher.TKIP);
+        wifi.allowedPairwiseCiphers.set(WifiConfiguration.PairwiseCipher.CCMP);
         wifi.allowedProtocols.set(WifiConfiguration.Protocol.WPA);
 
         wifi.networkId = ssidToNetworkId(newSSID, authType);

--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -375,7 +375,7 @@ public class WifiWizard2 extends CordovaPlugin {
 
       wifi.hiddenSSID = isHiddenSSID;
 
-      if (authType.equals("WPA")) {
+      if (authType.equals("WPA2")) {
        /**
         * WPA Data format:
         * 0: ssid
@@ -393,6 +393,27 @@ public class WifiWizard2 extends CordovaPlugin {
         wifi.allowedPairwiseCiphers.set(WifiConfiguration.PairwiseCipher.TKIP);
         wifi.allowedPairwiseCiphers.set(WifiConfiguration.PairwiseCipher.CCMP);
         wifi.allowedProtocols.set(WifiConfiguration.Protocol.RSN);
+        wifi.allowedProtocols.set(WifiConfiguration.Protocol.WPA);
+
+        wifi.networkId = ssidToNetworkId(newSSID, authType);
+
+      } else if (authType.equals("WPA")) {
+       /**
+        * WPA Data format:
+        * 0: ssid
+        * 1: auth
+        * 2: password
+        * 3: isHiddenSSID
+        */
+        wifi.SSID = newSSID;
+        wifi.preSharedKey = newPass;
+
+        wifi.status = WifiConfiguration.Status.ENABLED;
+        wifi.allowedGroupCiphers.set(WifiConfiguration.GroupCipher.TKIP);
+        wifi.allowedGroupCiphers.set(WifiConfiguration.GroupCipher.CCMP);
+        wifi.allowedKeyManagement.set(WifiConfiguration.KeyMgmt.WPA_PSK);
+        wifi.allowedPairwiseCiphers.set(WifiConfiguration.PairwiseCipher.TKIP);
+        wifi.allowedPairwiseCiphers.set(WifiConfiguration.PairwiseCipher.CCMP);
         wifi.allowedProtocols.set(WifiConfiguration.Protocol.WPA);
 
         wifi.networkId = ssidToNetworkId(newSSID, authType);
@@ -1233,6 +1254,22 @@ public class WifiWizard2 extends CordovaPlugin {
                 networkId = test.networkId;
               }
             }
+        }
+      }
+      if (networkId == -1 && authType.substring(0,3).equals('WPA')) {
+        for (WifiConfiguration test : currentNetworks) {
+          if (test.SSID != null) {
+              if (authType.length() == 0) {
+                if(test.SSID.equals(ssid)) {
+                  networkId = test.networkId;
+                }
+              } else {
+                String testSSID = test.SSID + this.getSecurityType(test).substring(0,3);
+                if(testSSID.equals(ssid + authType)) {
+                  networkId = test.networkId;
+                }
+              }
+          }
         }
       }
       return networkId;

--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -1251,7 +1251,7 @@ public class WifiWizard2 extends CordovaPlugin {
               return "WEP";
           case SECURITY_PSK:
               if (config.allowedProtocols.get(WifiConfiguration.Protocol.RSN))
-                  return "WPA2";
+                  return "WPA"; //Normally WPA2 but since we map everything to WPA it will be WPA
               else
                   return "WPA";
           default:

--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -377,7 +377,7 @@ public class WifiWizard2 extends CordovaPlugin {
 
       if (authType.equals("WPA2")) {
        /**
-        * WPA Data format:
+        * WPA2 Data format:
         * 0: ssid
         * 1: auth
         * 2: password
@@ -1241,7 +1241,7 @@ public class WifiWizard2 extends CordovaPlugin {
     } catch (NumberFormatException e) {
       List<WifiConfiguration> currentNetworks = wifiManager.getConfiguredNetworks();
       int networkId = -1;
-      // For each network in the list, compare the SSID with the given one
+      // For each network in the list, compare the SSID with the given one and check if authType matches
       for (WifiConfiguration test : currentNetworks) {
         if (test.SSID != null) {
             if (authType.length() == 0) {
@@ -1256,6 +1256,7 @@ public class WifiWizard2 extends CordovaPlugin {
             }
         }
       }
+      // Fallback to WPA if WPA2 is not found
       if (networkId == -1 && authType.substring(0,3).equals("WPA")) {
         for (WifiConfiguration test : currentNetworks) {
           if (test.SSID != null) {
@@ -1276,7 +1277,7 @@ public class WifiWizard2 extends CordovaPlugin {
     }
   }
 
-
+  // Get the different configured security types
   static public String getSecurityType(WifiConfiguration wifiConfig) {
 
     if (wifiConfig.allowedKeyManagement.get(WifiConfiguration.KeyMgmt.NONE)) {

--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -375,7 +375,7 @@ public class WifiWizard2 extends CordovaPlugin {
 
       wifi.hiddenSSID = isHiddenSSID;
 
-      if (authType.equals("WPA2")) {
+      if (authType.equals("WPA")) {
        /**
         * WPA Data format:
         * 0: ssid
@@ -393,27 +393,6 @@ public class WifiWizard2 extends CordovaPlugin {
         wifi.allowedPairwiseCiphers.set(WifiConfiguration.PairwiseCipher.TKIP);
         wifi.allowedPairwiseCiphers.set(WifiConfiguration.PairwiseCipher.CCMP);
         wifi.allowedProtocols.set(WifiConfiguration.Protocol.RSN);
-        wifi.allowedProtocols.set(WifiConfiguration.Protocol.WPA);
-
-        wifi.networkId = ssidToNetworkId(newSSID, authType);
-
-      } else if (authType.equals("WPA")) {
-       /**
-        * WPA Data format:
-        * 0: ssid
-        * 1: auth
-        * 2: password
-        * 3: isHiddenSSID
-        */
-        wifi.SSID = newSSID;
-        wifi.preSharedKey = newPass;
-
-        wifi.status = WifiConfiguration.Status.ENABLED;
-        wifi.allowedGroupCiphers.set(WifiConfiguration.GroupCipher.TKIP);
-        wifi.allowedGroupCiphers.set(WifiConfiguration.GroupCipher.CCMP);
-        wifi.allowedKeyManagement.set(WifiConfiguration.KeyMgmt.WPA_PSK);
-        wifi.allowedPairwiseCiphers.set(WifiConfiguration.PairwiseCipher.TKIP);
-        wifi.allowedPairwiseCiphers.set(WifiConfiguration.PairwiseCipher.CCMP);
         wifi.allowedProtocols.set(WifiConfiguration.Protocol.WPA);
 
         wifi.networkId = ssidToNetworkId(newSSID, authType);

--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -579,16 +579,18 @@ public class WifiWizard2 extends CordovaPlugin {
     }
 
     String ssidToDisable = "";
+    String authType = "";
 
     try {
       ssidToDisable = data.getString(0);
+      authType = data.getString(1);
     } catch (Exception e) {
       callbackContext.error(e.getMessage());
       Log.d(TAG, e.getMessage());
       return false;
     }
 
-    int networkIdToDisconnect = ssidToNetworkId(ssidToDisable);
+    int networkIdToDisconnect = ssidToNetworkId(ssidToDisable, authType);
 
     try {
 

--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -1214,7 +1214,7 @@ public class WifiWizard2 extends CordovaPlugin {
       // For each network in the list, compare the SSID with the given one
       for (WifiConfiguration test : currentNetworks) {
         if (test.SSID != null && test.SSID.equals(ssid)) {
-          networkId = test.networkId;
+          // networkId = test.networkId;
         }
       }
 

--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -1292,7 +1292,7 @@ public class WifiWizard2 extends CordovaPlugin {
             return "NONE";
         }
     } else if (wifiConfig.allowedProtocols.get(WifiConfiguration.Protocol.RSN)) {
-        return "WPA";//"WPA2";
+        return "WPA2";
     } else if (wifiConfig.allowedKeyManagement.get(WifiConfiguration.KeyMgmt.WPA_EAP)) {
         return "WPA";//"WPA_EAP";
     } else if (wifiConfig.allowedKeyManagement.get(WifiConfiguration.KeyMgmt.IEEE8021X)) {

--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -393,7 +393,7 @@ public class WifiWizard2 extends CordovaPlugin {
         wifi.allowedProtocols.set(WifiConfiguration.Protocol.RSN);
         wifi.allowedProtocols.set(WifiConfiguration.Protocol.WPA);
 
-        wifi.networkId = ssidToNetworkId(newSSID);
+        wifi.networkId = ssidToNetworkId(newSSID, authType);
 
       } else if (authType.equals("WEP")) {
        /**
@@ -425,7 +425,7 @@ public class WifiWizard2 extends CordovaPlugin {
         wifi.allowedProtocols.set(WifiConfiguration.Protocol.RSN);
         wifi.allowedProtocols.set(WifiConfiguration.Protocol.WPA);
 
-        wifi.networkId = ssidToNetworkId(newSSID);
+        wifi.networkId = ssidToNetworkId(newSSID, authType);
 
       } else if (authType.equals("NONE")) {
        /**
@@ -437,7 +437,7 @@ public class WifiWizard2 extends CordovaPlugin {
         */
         wifi.SSID = newSSID;
         wifi.allowedKeyManagement.set(WifiConfiguration.KeyMgmt.NONE);
-        wifi.networkId = ssidToNetworkId(newSSID);
+        wifi.networkId = ssidToNetworkId(newSSID, authType);
 
       } else {
 
@@ -518,7 +518,7 @@ public class WifiWizard2 extends CordovaPlugin {
       return;
     }
 
-    int networkIdToEnable = ssidToNetworkId(ssidToEnable);
+    int networkIdToEnable = ssidToNetworkId(ssidToEnable, "");
 
     try {
 
@@ -585,7 +585,7 @@ public class WifiWizard2 extends CordovaPlugin {
       return false;
     }
 
-    int networkIdToDisconnect = ssidToNetworkId(ssidToDisable);
+    int networkIdToDisconnect = ssidToNetworkId(ssidToDisable, "");
 
     try {
 
@@ -632,7 +632,7 @@ public class WifiWizard2 extends CordovaPlugin {
     try {
       String ssidToDisconnect = data.getString(0);
 
-      int networkIdToRemove = ssidToNetworkId(ssidToDisconnect);
+      int networkIdToRemove = ssidToNetworkId(ssidToDisconnect, "");
 
       if (networkIdToRemove > -1) {
 
@@ -690,7 +690,7 @@ public class WifiWizard2 extends CordovaPlugin {
       return;
     }
 
-    int networkIdToConnect = ssidToNetworkId(ssidToConnect);
+    int networkIdToConnect = ssidToNetworkId(ssidToConnect, "");
 
     if (networkIdToConnect > -1) {
       // We disable the network before connecting, because if this was the last connection before
@@ -813,7 +813,7 @@ public class WifiWizard2 extends CordovaPlugin {
       return false;
     }
 
-    int networkIdToDisconnect = ssidToNetworkId(ssidToDisconnect);
+    int networkIdToDisconnect = ssidToNetworkId(ssidToDisconnect, "");
 
     if (networkIdToDisconnect > 0) {
 
@@ -1089,7 +1089,7 @@ public class WifiWizard2 extends CordovaPlugin {
       return false;
     }
 
-    int networkIdToConnect = ssidToNetworkId(ssidToGetNetworkID);
+    int networkIdToConnect = ssidToNetworkId(ssidToGetNetworkID, "");
     callbackContext.success(networkIdToConnect);
 
     return true;
@@ -1198,7 +1198,7 @@ public class WifiWizard2 extends CordovaPlugin {
    * This method takes a given String, searches the current list of configured WiFi networks, and
    * returns the networkId for the network if the SSID matches. If not, it returns -1.
    */
-  private int ssidToNetworkId(String ssid) {
+  private int ssidToNetworkId(String ssid, String security) {
 
     try {
 
@@ -1213,8 +1213,10 @@ public class WifiWizard2 extends CordovaPlugin {
 
       // For each network in the list, compare the SSID with the given one
       for (WifiConfiguration test : currentNetworks) {
-        if (test.SSID != null && test.SSID.equals(ssid)) {
-          // networkId = test.networkId;
+        String testSecurity = this.getSecurity(test);
+        if (test.SSID != null && test.SSID.equals(ssid) && (testSecurity.equals(security) || security.length() == 0)) {
+           networkId = test.networkId;
+           
         }
       }
 
@@ -1222,7 +1224,7 @@ public class WifiWizard2 extends CordovaPlugin {
 
     }
   }
-
+ 
   /**
    * This method enables or disables the wifi
    */
@@ -1348,7 +1350,20 @@ public class WifiWizard2 extends CordovaPlugin {
         (ip >> 24 & 0xff)
     );
   }
-
+  private static String getSecurity(final WifiConfiguration network) {
+    if(network.allowedGroupCiphers.get(GroupCipher.CCMP)) {
+        return "WPA2";
+    }
+    else if(network.allowedGroupCiphers.get(GroupCipher.TKIP)) {
+        return "WPA";
+    }
+    else if(network.allowedGroupCiphers.get(GroupCipher.WEP40)
+            || network.allowedGroupCiphers.get(GroupCipher.WEP104)) {
+        return "WEP";
+    }
+    else return "NONE";
+  }
+  
   /**
    * Get IPv4 Subnet
    * @param inetAddress

--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -457,12 +457,13 @@ public class WifiWizard2 extends CordovaPlugin {
 
       // After processing authentication types, add or update network
       if (wifi.networkId == -1) { // -1 means SSID configuration does not exist yet
-
+        Log.d(TAG, "Add Network" + newSSID);
         int newNetId = wifiManager.addNetwork(wifi);
         if( newNetId > -1 ){
           this.networkId = newNetId;
           callbackContext.success( newNetId );
         } else {
+          Log.d(TAG, "Add Network Error" + newSSID);
           callbackContext.error( "ERROR_ADDING_NETWORK" );
           wifi.networkId = networkId;
           int updatedNetID = wifiManager.updateNetwork(wifi);

--- a/www/WifiWizard2.js
+++ b/www/WifiWizard2.js
@@ -8,7 +8,7 @@
  *      http://www.apache.org/licenses/LICENSE-2.0
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express oWPA2r implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
@@ -86,10 +86,6 @@ var WifiWizard2 = {
                 if (typeof wifi.auth == "object") {
 
                     switch (wifi.auth.algorithm) {
-		        case "WPA2":
-                            networkInformation.push("WPA2");
-                            networkInformation.push(wifi.auth.password);
-                            break;
                         case "WPA":
                             networkInformation.push("WPA");
                             networkInformation.push(wifi.auth.password);
@@ -570,12 +566,6 @@ var WifiWizard2 = {
             // open network
             wifiConfig.auth = {
                 algorithm: "NONE"
-            };
-        } else if (algorithm === "WPA2") {
-            wifiConfig.auth = {
-                algorithm: algorithm,
-                password: WifiWizard2.formatWifiString(password)
-                // Other parameters can be added depending on algorithm.
             };
         } else if (algorithm === "WPA") {
             wifiConfig.auth = {

--- a/www/WifiWizard2.js
+++ b/www/WifiWizard2.js
@@ -162,7 +162,7 @@ var WifiWizard2 = {
             WifiWizard2.add(wifiConfig).then(function (newNetID) {
 
                 // Successfully updated or added wifiConfig
-                cordova.exec(resolve, reject, "WifiWizard2", "connect", [WifiWizard2.formatWifiString(SSID), bindAll, algorithm || ""]);
+                cordova.exec(resolve, reject, "WifiWizard2", "connect", [WifiWizard2.formatWifiString(SSID), bindAll, wifiConfig.auth.algorithm || ""]);
 
                 // Catch error adding/updating network
             }).catch(function (error) {

--- a/www/WifiWizard2.js
+++ b/www/WifiWizard2.js
@@ -216,7 +216,7 @@ var WifiWizard2 = {
      * @param {string} [algorithm]
      * @returns {Promise<any>}
      */
-    enable: function (SSID, bindAll, waitForConnection) {
+    enable: function (SSID, bindAll, waitForConnection, algorithm) {
         return new Promise(function (resolve, reject) {
             bindAll = bindAll ? true : false;
             waitForConnection = waitForConnection ? true : false;
@@ -230,7 +230,7 @@ var WifiWizard2 = {
      * @param {string} [algorithm]
      * @returns {Promise<any>}
      */
-    disable: function (SSID) {
+    disable: function (SSID, algorithm) {
         return new Promise(function (resolve, reject) {
             cordova.exec(resolve, reject, "WifiWizard2", "disable", [WifiWizard2.formatWifiString(SSID), algorithm || ""]);
         });
@@ -402,7 +402,7 @@ var WifiWizard2 = {
      * @param {string} [algorithm]
      * @returns {Promise<any>}
      */
-    getSSIDNetworkID: function (SSID) {
+    getSSIDNetworkID: function (SSID, algorithm) {
         return new Promise(function (resolve, reject) {
             cordova.exec(resolve, reject, "WifiWizard2", "getSSIDNetworkID", [WifiWizard2.formatWifiString(SSID), algorithm || ""]);
         });

--- a/www/WifiWizard2.js
+++ b/www/WifiWizard2.js
@@ -86,6 +86,10 @@ var WifiWizard2 = {
                 if (typeof wifi.auth == "object") {
 
                     switch (wifi.auth.algorithm) {
+		    	case "WPA2":
+                            networkInformation.push("WPA2");
+                            networkInformation.push(wifi.auth.password);
+                            break;
                         case "WPA":
                             networkInformation.push("WPA");
                             networkInformation.push(wifi.auth.password);
@@ -566,6 +570,12 @@ var WifiWizard2 = {
             // open network
             wifiConfig.auth = {
                 algorithm: "NONE"
+            };
+        } else if (algorithm === "WPA2") {
+            wifiConfig.auth = {
+                algorithm: algorithm,
+                password: WifiWizard2.formatWifiString(password)
+                // Other parameters can be added depending on algorithm.
             };
         } else if (algorithm === "WPA") {
             wifiConfig.auth = {

--- a/www/WifiWizard2.js
+++ b/www/WifiWizard2.js
@@ -86,6 +86,10 @@ var WifiWizard2 = {
                 if (typeof wifi.auth == "object") {
 
                     switch (wifi.auth.algorithm) {
+		        case "WPA2":
+                            networkInformation.push("WPA2");
+                            networkInformation.push(wifi.auth.password);
+                            break;
                         case "WPA":
                             networkInformation.push("WPA");
                             networkInformation.push(wifi.auth.password);
@@ -566,6 +570,12 @@ var WifiWizard2 = {
             // open network
             wifiConfig.auth = {
                 algorithm: "NONE"
+            };
+        } else if (algorithm === "WPA2") {
+            wifiConfig.auth = {
+                algorithm: algorithm,
+                password: WifiWizard2.formatWifiString(password)
+                // Other parameters can be added depending on algorithm.
             };
         } else if (algorithm === "WPA") {
             wifiConfig.auth = {

--- a/www/WifiWizard2.js
+++ b/www/WifiWizard2.js
@@ -123,11 +123,12 @@ var WifiWizard2 = {
     /**
      * Remove wifi network configuration
      * @param {string|int} [SSID]
+     * @param {string} [algorithm]
      * @returns {Promise<any>}
      */
-    remove: function (SSID) {
+    remove: function (SSID, algorithm) {
         return new Promise(function (resolve, reject) {
-            cordova.exec(resolve, reject, "WifiWizard2", "remove", [WifiWizard2.formatWifiString(SSID)]);
+            cordova.exec(resolve, reject, "WifiWizard2", "remove", [WifiWizard2.formatWifiString(SSID), algorithm || ""]);
         });
     },
 
@@ -161,7 +162,7 @@ var WifiWizard2 = {
             WifiWizard2.add(wifiConfig).then(function (newNetID) {
 
                 // Successfully updated or added wifiConfig
-                cordova.exec(resolve, reject, "WifiWizard2", "connect", [WifiWizard2.formatWifiString(SSID), bindAll]);
+                cordova.exec(resolve, reject, "WifiWizard2", "connect", [WifiWizard2.formatWifiString(SSID), bindAll, algorithm || ""]);
 
                 // Catch error adding/updating network
             }).catch(function (error) {
@@ -172,7 +173,7 @@ var WifiWizard2 = {
 
                     // This error above should only be returned when the add method was able to pull a network ID (as it tries to update instead of adding)
                     // Lets go ahead and attempt to connect to that SSID (using the existing wifi configuration)
-                    cordova.exec(resolve, reject, "WifiWizard2", "connect", [WifiWizard2.formatWifiString(SSID), bindAll]);
+                    cordova.exec(resolve, reject, "WifiWizard2", "connect", [WifiWizard2.formatWifiString(SSID), bindAll, algorithm]);
 
                 } else {
 
@@ -192,13 +193,14 @@ var WifiWizard2 = {
      * call WifiWizard2.disable() instead of disconnect.
      *
      * @param {string|int} [SSID=all]
+     * @param {string} [algorithm]
      * @returns {Promise<any>}
      */
-    disconnect: function (SSID) {
+    disconnect: function (SSID, algorithm) {
         return new Promise(function (resolve, reject) {
 
             if (SSID) {
-                cordova.exec(resolve, reject, "WifiWizard2", "disconnectNetwork", [WifiWizard2.formatWifiString(SSID)]);
+                cordova.exec(resolve, reject, "WifiWizard2", "disconnectNetwork", [WifiWizard2.formatWifiString(SSID), algorithm || ""]);
             } else {
                 cordova.exec(resolve, reject, "WifiWizard2", "disconnect", []);
             }
@@ -211,24 +213,26 @@ var WifiWizard2 = {
      * @param {string|int} [SSID]
      * @param {boolean} [bindAll=false]                            Whether or not to bind all network requests to this wifi network
      * @param {boolean} [waitForConnection=false]        Whether or not to wait before resolving promise until connection to wifi is verified
+     * @param {string} [algorithm]
      * @returns {Promise<any>}
      */
     enable: function (SSID, bindAll, waitForConnection) {
         return new Promise(function (resolve, reject) {
             bindAll = bindAll ? true : false;
             waitForConnection = waitForConnection ? true : false;
-            cordova.exec(resolve, reject, "WifiWizard2", "enable", [WifiWizard2.formatWifiString(SSID), bindAll, waitForConnection]);
+            cordova.exec(resolve, reject, "WifiWizard2", "enable", [WifiWizard2.formatWifiString(SSID), bindAll, waitForConnection, algorithm || ""]);
         });
     },
 
     /**
      * Disable Network
      * @param {string|int} [SSID]
+     * @param {string} [algorithm]
      * @returns {Promise<any>}
      */
     disable: function (SSID) {
         return new Promise(function (resolve, reject) {
-            cordova.exec(resolve, reject, "WifiWizard2", "disable", [WifiWizard2.formatWifiString(SSID)]);
+            cordova.exec(resolve, reject, "WifiWizard2", "disable", [WifiWizard2.formatWifiString(SSID), algorithm || ""]);
         });
     },
 
@@ -395,11 +399,12 @@ var WifiWizard2 = {
     /**
      * Get Network ID from SSID
      * @param {string|int} [SSID]
+     * @param {string} [algorithm]
      * @returns {Promise<any>}
      */
     getSSIDNetworkID: function (SSID) {
         return new Promise(function (resolve, reject) {
-            cordova.exec(resolve, reject, "WifiWizard2", "getSSIDNetworkID", [WifiWizard2.formatWifiString(SSID)]);
+            cordova.exec(resolve, reject, "WifiWizard2", "getSSIDNetworkID", [WifiWizard2.formatWifiString(SSID), algorithm || ""]);
         });
     },
 

--- a/www/WifiWizard2.js
+++ b/www/WifiWizard2.js
@@ -562,6 +562,7 @@ var WifiWizard2 = {
             wifiConfig.auth = {
                 algorithm: "NONE"
             };
+	    wifiConfig.SSID = wifiConfig.SSID + "NONE";
         } else if (algorithm === "WPA") {
             wifiConfig.auth = {
                 algorithm: algorithm,

--- a/www/WifiWizard2.js
+++ b/www/WifiWizard2.js
@@ -567,7 +567,6 @@ var WifiWizard2 = {
             wifiConfig.auth = {
                 algorithm: "NONE"
             };
-	    wifiConfig.SSID = wifiConfig.SSID + "NONE";
         } else if (algorithm === "WPA") {
             wifiConfig.auth = {
                 algorithm: algorithm,

--- a/www/WifiWizard2.js
+++ b/www/WifiWizard2.js
@@ -173,7 +173,7 @@ var WifiWizard2 = {
 
                     // This error above should only be returned when the add method was able to pull a network ID (as it tries to update instead of adding)
                     // Lets go ahead and attempt to connect to that SSID (using the existing wifi configuration)
-                    cordova.exec(resolve, reject, "WifiWizard2", "connect", [WifiWizard2.formatWifiString(SSID), bindAll, algorithm]);
+                    cordova.exec(resolve, reject, "WifiWizard2", "connect", [WifiWizard2.formatWifiString(SSID), bindAll, wifiConfig.auth.algorithm || ""]);
 
                 } else {
 


### PR DESCRIPTION
### Description of the Change

Differentiate between different network authentication types when retrieving networks by SSID. This is necessary because android stores multiple networks with same SSID but different types.

### Benefits

Fixes a problem where one cannot connect to an unsecured network when there is a configuartion with WPA/WPA2 already configured.
