### PR TITLE
add connected and unavailable callback for Api >= 29

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cordova-plugin-wifiwizard2",
   "version": "3.1.1",
   "cordova": {
-    "id": "wifiwizard2",
+    "id": "cordova-plugin-wifiwizard2",
     "platforms": [
       "android",
       "ios"
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tripflex/wifiwizard2.git"
+    "url": "git+https://github.com/maxcodefaster/WifiWizard2.git"
   },
   "author": "Myles McNamara",
   "license": "Apache 2.0",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,14 +2,14 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
-        id="wifiwizard2"
+        id="cordova-plugin-wifiwizard2"
         version="3.1.1">
 
     <name>WifiWizard2</name>
     <description>Cordova Wifi Manager for Android and iOS</description>
     <license>Apache 2.0</license>
     <keywords>cordova,network,wifi,phonegap</keywords>
-    <repo>https://github.com/tripflex/wifiwizard2.git</repo>
+    <repo>https://github.com/maxcodefaster/WifiWizard2.git</repo>
     <issue>https://github.com/tripflex/wifiwizard2/issues</issue>
 
     <js-module src="www/WifiWizard2.js" name="WifiWizard2">

--- a/src/android/wifiwizard2/WifiWizard2.java
+++ b/src/android/wifiwizard2/WifiWizard2.java
@@ -465,10 +465,18 @@ public class WifiWizard2 extends CordovaPlugin {
       }
 
       if(API_VERSION >= 29) {
-        networkCallback = new ConnectivityManager.NetworkCallback() {
+        this.networkCallback = new ConnectivityManager.NetworkCallback() {
           @Override
           public void onAvailable(Network network) {
-            connectivityManager.setProcessDefaultNetwork(network);
+            connectivityManager.bindProcessToNetwork(network);
+            Log.d(TAG, "WiFi connected");
+            callbackContext.success("WiFi connected");
+          }
+          @Override
+          public void onUnavailable() {
+           super.onUnavailable();
+           Log.d(TAG, "WiFi not available");
+           callbackContext.error("WiFi not available");
           }
         };
 
@@ -480,11 +488,14 @@ public class WifiWizard2 extends CordovaPlugin {
 
         NetworkRequest.Builder networkRequestBuilder1 = new NetworkRequest.Builder();
         networkRequestBuilder1.addTransportType(NetworkCapabilities.TRANSPORT_WIFI);
+        //removeCapability added for hotspots without internet
+        networkRequestBuilder1.removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
         networkRequestBuilder1.setNetworkSpecifier(wifiNetworkSpecifier);
 
         NetworkRequest nr = networkRequestBuilder1.build();
         ConnectivityManager cm = (ConnectivityManager) cordova.getActivity().getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
-        cm.requestNetwork(nr, this.networkCallback);
+        //timeout add because "No devices found" wasn't handled correct and doesn't throw Unavailable
+        cm.requestNetwork(nr, this.networkCallback, 15000);
       } else {
         // After processing authentication types, add or update network
         if(wifi.networkId == -1) { // -1 means SSID configuration does not exist yet
@@ -882,6 +893,7 @@ public class WifiWizard2 extends CordovaPlugin {
       try{
           ConnectivityManager cm = (ConnectivityManager) cordova.getActivity().getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
           cm.unregisterNetworkCallback(this.networkCallback);
+          connectivityManager.bindProcessToNetwork(null);
           return true;
         }
         catch(Exception e) {
@@ -1831,7 +1843,7 @@ public class WifiWizard2 extends CordovaPlugin {
       // Marshmallow (API 23+) or newer uses bindProcessToNetwork
       final NetworkRequest request = new NetworkRequest.Builder()
           .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
-//          .removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+          .removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
           .build();
 
       networkCallback = new ConnectivityManager.NetworkCallback() {
@@ -1855,7 +1867,7 @@ public class WifiWizard2 extends CordovaPlugin {
       // Lollipop (API 21-22) use setProcessDefaultNetwork (deprecated in API 23 - Marshmallow)
       final NetworkRequest request = new NetworkRequest.Builder()
           .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
-//          .removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+          .removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
           .build();
 
       networkCallback = new ConnectivityManager.NetworkCallback() {

--- a/www/WifiWizard2.js
+++ b/www/WifiWizard2.js
@@ -161,8 +161,11 @@ var WifiWizard2 = {
             WifiWizard2.add(wifiConfig).then(function (newNetID) {
 
                 // Successfully updated or added wifiConfig
-                cordova.exec(resolve, reject, "WifiWizard2", "connect", [WifiWizard2.formatWifiString(SSID), bindAll]);
-
+                if(device.platform === "Android" && !(parseInt(device.version.split('.')[0]) >= 10)) {
+					cordova.exec(resolve, reject, "WifiWizard2", "connect", [WifiWizard2.formatWifiString(SSID), bindAll]);
+				} else {
+                    resolve(newNetID);
+                }
                 // Catch error adding/updating network
             }).catch(function (error) {
 
@@ -172,7 +175,9 @@ var WifiWizard2 = {
 
                     // This error above should only be returned when the add method was able to pull a network ID (as it tries to update instead of adding)
                     // Lets go ahead and attempt to connect to that SSID (using the existing wifi configuration)
-                    cordova.exec(resolve, reject, "WifiWizard2", "connect", [WifiWizard2.formatWifiString(SSID), bindAll]);
+                    if(device.platform === "Android" && !(parseInt(device.version.split('.')[0]) >= 10)) {
+						cordova.exec(resolve, reject, "WifiWizard2", "connect", [WifiWizard2.formatWifiString(SSID), bindAll]);
+					}
 
                 } else {
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Added connected and unavailable callback for Android Api >= 29

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

Fixed missing callback

<!-- Explain why this functionality should be in atom/atom as opposed to a package -->

### Benefits

<!-- What benefits will be realized by the code change? -->
Fix Bugs

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues
https://github.com/tripflex/WifiWizard2/issues/113

<!-- Enter any applicable Issues here -->