### PR TITLE
Remove all networkextension

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -58,12 +58,6 @@
         <config-file parent="com.apple.developer.networking.HotspotConfiguration" target="*/Entitlements-Release.plist">
                  <true/>
         </config-file>
-        <config-file parent="com.apple.developer.networking.networkextension" target="*/Entitlements-Debug.plist">
-                <array/>
-        </config-file>
-        <config-file parent="com.apple.developer.networking.networkextension" target="*/Entitlements-Release.plist">
-                <array/>
-        </config-file>
 	<config-file parent="com.apple.developer.networking.wifi-info" target="*/Entitlements-Debug.plist">
                 <true/>
         </config-file>


### PR DESCRIPTION
As per https://github.com/tripflex/WifiWizard2/issues/116
We need to remove all empty com.apple.developer.networking.networkextension to be able to build for iOS

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

I removed all empty com.apple.developer.networking.networkextension to be able to build for iOS
As per https://github.com/tripflex/WifiWizard2/issues/116 this prevented me from builing on iOS
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

We could have added the String inside the PL file, but I am not sure which ones are used
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

So iOS is able to build
<!-- Explain why this functionality should be in atom/atom as opposed to a package -->

### Benefits

People can build iOS Apps
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Maybe we need the empty networkextension?
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->